### PR TITLE
Set the Spring Boot version on the parent block in any pom in a project

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -44,3 +44,18 @@ executor:
     branch: "n/a"
     sha: "n/a"
 
+---
+kind: "operation"
+client: "rug-cli 0.21.3"
+executor:
+  name: "SetSpringBootParentVersionExecutor"
+  group: "atomist-rugs"
+  artifact: "spring-boot-editors"
+  version: "0.5.2"
+  origin:
+    repo: "https://github.com/atomist-rugs/spring-boot-editors.git"
+    branch: "2e4b222888ddbdee38a88d9d420119b859d0a508"
+    sha: "2e4b222"
+  parameters:
+    - "spring_boot_version": "1.4.4.RELEASE"
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>atomist</groupId>
@@ -12,11 +11,11 @@
 	<description>Atomist Spring Rest start project</description>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.1.RELEASE</version>
-		<relativePath /> <!-- lookup parent from repository -->
-	</parent>
+  <groupId>org.springframework.boot</groupId>
+  <artifactId>spring-boot-starter-parent</artifactId>
+  <version>1.4.4.RELEASE</version>
+  <relativePath/> <!-- lookup parent from repository -->
+</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Created by Atomist Executor SetSpringBootParentVersionExecutor
```
---
kind: "operation"
client: "rug-cli 0.21.3"
executor:
  name: "SetSpringBootParentVersionExecutor"
  group: "atomist-rugs"
  artifact: "spring-boot-editors"
  version: "0.5.2"
  origin:
    repo: "https://github.com/atomist-rugs/spring-boot-editors.git"
    branch: "2e4b222888ddbdee38a88d9d420119b859d0a508"
    sha: "2e4b222"
  parameters:
    - "spring_boot_version": "1.4.4.RELEASE"


```